### PR TITLE
Add reranking stage to retrieval flow

### DIFF
--- a/.env
+++ b/.env
@@ -4,11 +4,14 @@ DATA_DIR=./data
 # Storage directory for LlamaIndex index
 STORAGE_DIR=./storage
 
-# Hugging Face embedding model for semantic search
-EMB_MODEL_NAME=BAAI/bge-small-en-v1.5
+# Retrieval step 1: embedding search (vector similarity)
+RETRIEVAL_EMBED_MODEL_NAME=BAAI/bge-small-en-v1.5
+RETRIEVAL_MODEL_CACHE_DIR=./models
+RETRIEVAL_EMBED_TOP_K=10
 
-# Retrieval settings
-SIMILARITY_TOP_K=5
+# Retrieval step 2: cross-encoder reranking (final results returned)
+RETRIEVAL_RERANK_MODEL_NAME=cross-encoder/ms-marco-MiniLM-L-6-v2
+RETRIEVAL_RERANK_TOP_K=5
 
 # Avoids any attempts to connect online (including by python libraries)
 OFFLINE=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 llama-index>=0.10.0
 llama-index-readers-file>=0.1.0
 llama-index-embeddings-fastembed>=0.1.0
+sentence-transformers>=2.6.1
 pymupdf>=1.23.0
 python-docx>=1.1.0
 modelcontextprotocol>=0.5.0


### PR DESCRIPTION
## Summary
- add a cross-encoder reranking stage to `retrieve_docs` with configurable embedding and rerank top-k values
- cache the reranker alongside the embedding model during ingestion/download for offline release bundles
- update configuration docs, environment template, and dependencies for the two-stage retrieval pipeline

## Testing
- pip install -r requirements.txt *(fails: package index blocked when installing sentence-transformers)*
- pytest *(fails: ModuleNotFoundError: sentence_transformers during collection)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ea3ad5d0833281cd5460268ecffb)