### PR TITLE
chore: rename project to ChunkSilo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# On-Prem Docs MCP Server
+# ChunkSilo
+
+On-Prem Docs MCP Server
 
 Fully local semantic search for your PDF, DOCX, Markdown, and TXT files. The MCP server only retrieves chunks; your LLM (via Continue, Cline, or Roo Code) does the answering. No data leaves your machine.
 
@@ -13,14 +15,14 @@ Fully local semantic search for your PDF, DOCX, Markdown, and TXT files. The MCP
 
 ## Quick Installation (Recommended)
 
-The easiest way to install is using the self-contained installer script from the [Releases page](https://github.com/Chetic/opd-mcp/releases).
+The easiest way to install is using the self-contained installer script from the [Releases page](https://github.com/Chetic/ChunkSilo/releases).
 
-1. **Download** the `opd-mcp-vX.Y.Z-installer.sh` file.
+1. **Download** the `ChunkSilo-vX.Y.Z-installer.sh` file.
 2. **Run** the installer:
 
 ```bash
-chmod +x opd-mcp-installer.sh
-./opd-mcp-installer.sh
+chmod +x ChunkSilo-installer.sh
+./ChunkSilo-installer.sh
 ```
 
 All parameters are optional. The installer will ask you for any required information if it is not provided via flags.
@@ -32,7 +34,7 @@ All parameters are optional. The installer will ask you for any required informa
 | `--tool <name>` | Target tool to configure: `cline`, `roo`, `continue`. |
 | `--project [path]` | Configure for a specific project. Defaults to global if omitted. |
 | `--editor <name>` | For global install: `code`, `cursor`, `windsurf`, `antigravity`, `vscodium`, etc. Auto-detects VS Code if it's the only available editor. |
-| `--location <path>` | Install destination (defaults to `/data/opd-mcp`, `/localhome/opd-mcp`, or `~/opd-mcp`). |
+| `--location <path>` | Install destination (defaults to `/data/ChunkSilo`, `/localhome/ChunkSilo`, or `~/ChunkSilo`). |
 | `--overwrite` | Force overwrite of existing files and configs. |
 
 ## Manual / Developer Installation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ The script will:
 ## Output
 
 The built package is placed in the `build-output/` directory:
-- `opd-mcp-{VERSION}-manylinux_2_34_x86_64.zip`
+- `ChunkSilo-{VERSION}-manylinux_2_34_x86_64.zip`
 
 ## Cleanup
 

--- a/scripts/build_installer.sh
+++ b/scripts/build_installer.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 BUILD_DIR="$REPO_ROOT/build-output"
 PAYLOAD_ROOT="${1:-}"
-ARTIFACT_NAME="opd-mcp-installer.sh"
+ARTIFACT_NAME="ChunkSilo-installer.sh"
 
 mkdir -p "$BUILD_DIR"
 
@@ -16,10 +16,10 @@ echo "Building installer..."
 # Pick a payload root that already contains pre-downloaded wheels so the
 # installer remains fully offline.
 if [ -z "$PAYLOAD_ROOT" ]; then
-    if [ -d "$REPO_ROOT/release_package_manylinux_2_34/opd-mcp" ]; then
-        PAYLOAD_ROOT="$REPO_ROOT/release_package_manylinux_2_34/opd-mcp"
-    elif [ -d "$REPO_ROOT/release_package_manylinux_2_28/opd-mcp" ]; then
-        PAYLOAD_ROOT="$REPO_ROOT/release_package_manylinux_2_28/opd-mcp"
+    if [ -d "$REPO_ROOT/release_package_manylinux_2_34/ChunkSilo" ]; then
+        PAYLOAD_ROOT="$REPO_ROOT/release_package_manylinux_2_34/ChunkSilo"
+    elif [ -d "$REPO_ROOT/release_package_manylinux_2_28/ChunkSilo" ]; then
+        PAYLOAD_ROOT="$REPO_ROOT/release_package_manylinux_2_28/ChunkSilo"
     else
         PAYLOAD_ROOT="$REPO_ROOT"
     fi

--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -105,13 +105,13 @@ def generate_cline_config(config, output_dir, cwd, force=False):
     }
     
     # Rules
-    # User requested: "write (and overwrite) its own opd-mcp.md file to the global clinerules directory"
+    # User requested: "write (and overwrite) its own ChunkSilo.md file to the global clinerules directory"
     # The output_dir passed in for Cline global is typically ".../settings".
     # We should look for "prompts" or "rules" directory relative to it?
     # Standard Cline (Claude Dev) separation isn't strictly defined for global rules, BUT
     # recent updates added Custom Instructions which are stored in `globalStorage/saoudrizwan.claude-dev/settings/cline_custom_instructions.json`?
     # OR user likely has a `rules` folder if they are asking for this.
-    # Let's attempt to write to `opd-mcp.md` in the same directory, or if a `rules` subdir exists.
+    # Let's attempt to write to `ChunkSilo.md` in the same directory, or if a `rules` subdir exists.
     
     os.makedirs(output_dir, exist_ok=True)
     
@@ -119,10 +119,10 @@ def generate_cline_config(config, output_dir, cwd, force=False):
 
     # For rules, we write a separate markdown file as requested.
     # We will try to place it in 'rules' subdir if it exists, otherwise in current dir?
-    # Or just `opd-mcp-rules.md` in the settings dir to be safe.
+    # Or just `ChunkSilo-rules.md` in the settings dir to be safe.
     
     rules_content = config["rules"]["system_prompt"]
-    rules_path = os.path.join(output_dir, "opd-mcp-rules.md")
+    rules_path = os.path.join(output_dir, "ChunkSilo-rules.md")
     
     # Check if a rules directory is expected?
     # "global clinerules directory".
@@ -157,18 +157,18 @@ def generate_roo_config(config, output_dir, cwd, force=False):
     os.makedirs(rules_dir, exist_ok=True)
     
     # Write separate rule file
-    safe_write_text(os.path.join(rules_dir, "opd-mcp-rules.md"), config["rules"]["system_prompt"], force)
+    safe_write_text(os.path.join(rules_dir, "ChunkSilo-rules.md"), config["rules"]["system_prompt"], force)
     
     print(f"Generated Roo Code config in {output_dir}")
 
 def generate_continue_config(config, output_dir, cwd, force=False):
-    # mcpServers/opd-mcp.yaml
+    # mcpServers/ChunkSilo.yaml
     
     servers_dir = os.path.join(output_dir, "mcpServers")
     os.makedirs(servers_dir, exist_ok=True)
     
     # Continue supports multiple config files, so we simply write our own.
-    # This is already "separate" (opd-mcp.yaml).
+    # This is already "separate" (ChunkSilo.yaml).
     # We still check if it exists and backup.
     
     server_name = config["mcp_server"]["name"]
@@ -195,14 +195,14 @@ mcpServers:
         for k, v in env.items():
             yaml_content += f"\n      {k}: {v}"
             
-    safe_write_text(os.path.join(servers_dir, "opd-mcp.yaml"), yaml_content, force)
+    safe_write_text(os.path.join(servers_dir, "ChunkSilo.yaml"), yaml_content, force)
         
     # Rules
     # Continue rules can be separate files too.
     rules_dir = os.path.join(output_dir, "rules")
     os.makedirs(rules_dir, exist_ok=True)
     
-    safe_write_text(os.path.join(rules_dir, "opd-mcp-system-prompt.md"), config["rules"]["system_prompt"], force)
+    safe_write_text(os.path.join(rules_dir, "ChunkSilo-system-prompt.md"), config["rules"]["system_prompt"], force)
         
     print(f"Generated Continue config in {output_dir}")
 

--- a/scripts/package-manylinux-2_28.sh
+++ b/scripts/package-manylinux-2_28.sh
@@ -32,7 +32,7 @@ if [ -z "$GITHUB_ACTIONS" ] && [ ! -f /etc/redhat-release ]; then
     "$CONTAINER_IMAGE" \
     bash /workspace/scripts/package-manylinux-2_28.sh "$VERSION"
   
-  echo "Package built successfully: build-output/opd-mcp-${VERSION}-manylinux_2_28_x86_64.tar.gz"
+  echo "Package built successfully: build-output/ChunkSilo-${VERSION}-manylinux_2_28_x86_64.tar.gz"
   exit 0
 fi
 
@@ -50,7 +50,7 @@ fi
 dnf install -y python3.11 python3.11-pip git which gcc gcc-c++ make
 
 # Prepare manylinux_2_28 release package
-PACKAGE_ROOT="release_package_manylinux_2_28/opd-mcp"
+PACKAGE_ROOT="release_package_manylinux_2_28/ChunkSilo"
 mkdir -p "$PACKAGE_ROOT"
 
 # Copy common files and models (including hidden files/directories)
@@ -122,16 +122,16 @@ WORK_DIR="/workspace"
 
 if [ -n "$GITHUB_ACTIONS" ] && [ -z "$LOCAL_DOCKER" ]; then
   # In actual CI, output to current directory
-  OUTPUT_TAR="opd-mcp-${VERSION}-manylinux_2_28_x86_64.tar.gz"
+  OUTPUT_TAR="ChunkSilo-${VERSION}-manylinux_2_28_x86_64.tar.gz"
   TAR_PATH="../$OUTPUT_TAR"
   FINAL_OUTPUT="$OUTPUT_TAR"
 else
   # Local Docker execution or when LOCAL_DOCKER is set, output to build-output directory
   OUTPUT_DIR="$WORK_DIR/build-output"
   mkdir -p "$OUTPUT_DIR"
-  OUTPUT_TAR="$OUTPUT_DIR/opd-mcp-${VERSION}-manylinux_2_28_x86_64.tar.gz"
+  OUTPUT_TAR="$OUTPUT_DIR/ChunkSilo-${VERSION}-manylinux_2_28_x86_64.tar.gz"
   # Create tarball in current directory first, then move it
-  TEMP_TAR="opd-mcp-${VERSION}-manylinux_2_28_x86_64.tar.gz"
+  TEMP_TAR="ChunkSilo-${VERSION}-manylinux_2_28_x86_64.tar.gz"
   TAR_PATH="../$TEMP_TAR"
   FINAL_OUTPUT="$OUTPUT_TAR"
 fi

--- a/scripts/package-manylinux-2_34.sh
+++ b/scripts/package-manylinux-2_34.sh
@@ -32,7 +32,7 @@ if [ -z "$GITHUB_ACTIONS" ] && [ ! -f /etc/redhat-release ]; then
     "$CONTAINER_IMAGE" \
     bash /workspace/scripts/package-manylinux-2_34.sh "$VERSION"
   
-  echo "Package built successfully: build-output/opd-mcp-${VERSION}-manylinux_2_34_x86_64.tar.gz"
+  echo "Package built successfully: build-output/ChunkSilo-${VERSION}-manylinux_2_34_x86_64.tar.gz"
   exit 0
 fi
 
@@ -50,7 +50,7 @@ fi
 dnf install -y python3.11 python3.11-pip git which gcc gcc-c++ make
 
 # Prepare manylinux_2_34 release package
-PACKAGE_ROOT="release_package_manylinux_2_34/opd-mcp"
+PACKAGE_ROOT="release_package_manylinux_2_34/ChunkSilo"
 mkdir -p "$PACKAGE_ROOT"
 
 # Copy common files and models (including hidden files/directories)
@@ -147,16 +147,16 @@ WORK_DIR="/workspace"
 
 if [ -n "$GITHUB_ACTIONS" ] && [ -z "$LOCAL_DOCKER" ]; then
   # In actual CI, output to current directory
-  OUTPUT_TAR="opd-mcp-${VERSION}-manylinux_2_34_x86_64.tar.gz"
+  OUTPUT_TAR="ChunkSilo-${VERSION}-manylinux_2_34_x86_64.tar.gz"
   TAR_PATH="../$OUTPUT_TAR"
   FINAL_OUTPUT="$OUTPUT_TAR"
 else
   # Local Docker execution or when LOCAL_DOCKER is set, output to build-output directory
   OUTPUT_DIR="$WORK_DIR/build-output"
   mkdir -p "$OUTPUT_DIR"
-  OUTPUT_TAR="$OUTPUT_DIR/opd-mcp-${VERSION}-manylinux_2_34_x86_64.tar.gz"
+  OUTPUT_TAR="$OUTPUT_DIR/ChunkSilo-${VERSION}-manylinux_2_34_x86_64.tar.gz"
   # Create tarball in current directory first, then move it
-  TEMP_TAR="opd-mcp-${VERSION}-manylinux_2_34_x86_64.tar.gz"
+  TEMP_TAR="ChunkSilo-${VERSION}-manylinux_2_34_x86_64.tar.gz"
   TAR_PATH="../$TEMP_TAR"
   FINAL_OUTPUT="$OUTPUT_TAR"
 fi

--- a/scripts/stub.sh
+++ b/scripts/stub.sh
@@ -5,9 +5,9 @@ set -e
 
 # Create a temporary directory for extraction.
 # Avoid /tmp to support systems where it is not writable.
-BASE_TEMP_DIR=${TMPDIR:-"$HOME/.cache/opd-mcp"}
+BASE_TEMP_DIR=${TMPDIR:-"$HOME/.cache/ChunkSilo"}
 mkdir -p "$BASE_TEMP_DIR"
-TEMP_DIR=$(mktemp -d "$BASE_TEMP_DIR/opd-mcp-installer.XXXXXXXX")
+TEMP_DIR=$(mktemp -d "$BASE_TEMP_DIR/ChunkSilo-installer.XXXXXXXX")
 LAUNCH_DIR=$(pwd)
 
 # Function to cleanup temp dir

--- a/setup.sh
+++ b/setup.sh
@@ -32,11 +32,11 @@ is_writable() {
 # Determine default install location
 determine_install_dir() {
     if [ -d "/data" ] && is_writable "/data"; then
-        echo "/data/opd-mcp"
+        echo "/data/ChunkSilo"
     elif [ -d "/localhome" ] && is_writable "/localhome"; then
-        echo "/localhome/opd-mcp"
+        echo "/localhome/ChunkSilo"
     else
-        echo "$HOME/opd-mcp"
+        echo "$HOME/ChunkSilo"
     fi
 }
 
@@ -76,7 +76,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-echo "=== opd-mcp Installer ==="
+echo "=== ChunkSilo Installer ==="
 
 # Prerequisites check
 find_python() {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for opd-mcp tests."""
+"""Shared pytest fixtures for ChunkSilo tests."""
 import os
 import pytest
 from pathlib import Path

--- a/universal_config.json
+++ b/universal_config.json
@@ -1,6 +1,6 @@
 {
     "mcp_server": {
-        "name": "opd-mcp",
+        "name": "ChunkSilo",
         "command": "venv/bin/python",
         "args": [
             "mcp_server.py"


### PR DESCRIPTION
### Motivation

- Rebrand the project from `opd-mcp` to `ChunkSilo` so docs, installer artifacts, and tooling consistently use the new name.
- Ensure generated configs and packaging scripts produce `ChunkSilo`-named artifacts and default install locations.

### Description

- Updated top-level documentation in `README.md` to use the `ChunkSilo` title, release link, and installer filenames (e.g., `ChunkSilo-installer.sh`).
- Renamed the MCP server name in `universal_config.json` to `ChunkSilo` so generated configs use the new service name.
- Updated installer and packaging scripts (`scripts/build_installer.sh`, `scripts/package-manylinux-2_28.sh`, `scripts/package-manylinux-2_34.sh`, `scripts/stub.sh`, `setup.sh`) to reference `ChunkSilo` for default install paths, artifact names, and payload directories.
- Adjusted `scripts/generate_configs.py` and `test/conftest.py` to emit `ChunkSilo`-named config/rules files and to update test fixtures docstrings accordingly.

### Testing

- Ran the project test suite using the recommended command `cd test && ./run_tests.sh` (equivalently `python3 -m pytest test/ -v --ignore=test/test_large_scale.py`).
- Test run: collected 87 tests, `85` passed and `2` failed. The two failing tests are ingestion-related (`test_ingestion` in retrieval/system tests) and failed due to a network `403 Forbidden` from the environment proxy while attempting to download embedding model artifacts.
- All other automated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721e81f5bc83329f39c104960b78dd)